### PR TITLE
New Rubocop (0.46) requires a version parameter.

### DIFF
--- a/Support/rubocop.rb
+++ b/Support/rubocop.rb
@@ -14,7 +14,7 @@ def log(msg)
 end
 
 def offences(file)
-  processed_source = RuboCop::ProcessedSource.from_file(file)
+  processed_source = RuboCop::ProcessedSource.from_file(file, RUBY_VERSION[0..2].to_f)
   team = RuboCop::Cop::Team.new(
     RuboCop::Cop::Cop.all,
     RuboCop::ConfigStore.new.for(processed_source.path),


### PR DESCRIPTION
New version of Rubocop (0.46) as of Dec 2016 requires a second parameter for the Ruby version in float.