### PR TITLE
exclude erb files from scope

### DIFF
--- a/Commands/Rubocop.tmCommand
+++ b/Commands/Rubocop.tmCommand
@@ -27,7 +27,7 @@ fi
 	<key>outputLocation</key>
 	<string>discard</string>
 	<key>scope</key>
-	<string>source.ruby</string>
+	<string>source.ruby - (L:text.html.erb)</string>
 	<key>semanticClass</key>
 	<string>callback.document.did-save</string>
 	<key>uuid</key>

--- a/Commands/Rubocop.tmCommand
+++ b/Commands/Rubocop.tmCommand
@@ -27,7 +27,7 @@ fi
 	<key>outputLocation</key>
 	<string>discard</string>
 	<key>scope</key>
-	<string>source.ruby - (L:text.html.erb)</string>
+	<string>source.ruby - (source.ruby.embedded, source.ruby.rails.embedded, meta.embedded.line.erb, meta.embedded.block.erb, markup.raw.block.ruby)</string>
 	<key>semanticClass</key>
 	<string>callback.document.did-save</string>
 	<key>uuid</key>


### PR DESCRIPTION
Since linting erb files doesn't work, and actually causes errors:

![image](https://user-images.githubusercontent.com/351038/29248905-4a522f1a-8024-11e7-8b7a-e62c1aa5ccb0.png)
