### PR TITLE
Update README for new TM bundle directory + rvm-specific instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,27 @@ Supports
 Install
 -------
 
-Make sure $TM_RUBY is set to current ruby directory, then:
+First, make sure `$TM_RUBY` is set to your current ruby directory.
+
+_**Important:** If you're using `rvm`, see "Installation notes for `rvm` users" below._
+
+Once `$TM_RUBY` has been properly set, finish the installation:
 
     gem install rubocop
-    mkdir -p ~/Library/Application\ Support/Avian/Bundles
-    cd ~/Library/Application\ Support/Avian/Bundles
+    mkdir -p ~/Library/Application\ Support/TextMate/Bundles
+    cd ~/Library/Application\ Support/TextMate/Bundles
     git clone https://github.com/fazibear/Rubocop.tmbundle.git
+
+Installation notes for `rvm` users
+----------------------------------
+
+You may need to [generate a wrapper](https://rvm.io/integration/textmate) to ensure that TextMate uses the correct `ruby` binary when executing the bundle (in this example we'll use ruby 2.4.1; be sure to substitute if you're using something different):
+
+1. Switch to your preferred Ruby: `rvm use 2.4.1`
+2. `gem install rubocop`
+3. `rvm wrapper 2.4.1 textmate`
+4. Assign `TM_RUBY` to the full value of `which textmate_ruby` (something like `/Users/you/.rvm/bin/textmate_ruby`)
+5. Continue the installation per the instructions above.
 
 Screenshot
 ----------


### PR DESCRIPTION
First, the new bundle directory is in `~/Library/Application Support/TextMate`.

Second, I had some difficulty getting TextMate to use the proper `rvm`-installed version of `ruby` when executing the bundle. I've added an _Installation notes for `rvm` users_ to the `README` with the procedure I had to follow to get it working.